### PR TITLE
missing declaration of g:cursor_follows_alphabet

### DIFF
--- a/plugin/translit.vim
+++ b/plugin/translit.vim
@@ -70,6 +70,9 @@ if ! exists('g:translit_toggle_keymap')
     let g:translit_toggle_keymap='<C-T>'
 endif
 
+if ! exists('g:cursor_follows_alphabet')
+    let g:cursor_follows_alphabet=1
+endif
 
 command! TranslitOff call TranslitOff()
 command! ToggleTranslit call ToggleTranslit()


### PR DESCRIPTION
Attempting to use translit.vim resulted in an error:

```
Using translit.ru transliteration
Error detected while processing function Translit..TranslitCaptureCursor:
line    1:
E121: Undefined variable: g:cursor_follows_alphabet
E15: Invalid expression: g:cursor_follows_alphabet != 0
```

This pull request fixes that issue by declaring g:cursor_follows_alphabet, defaulting to 1
